### PR TITLE
refactor: use relative paths instead of hardcoded URLs

### DIFF
--- a/youtube-extractor.html
+++ b/youtube-extractor.html
@@ -450,7 +450,7 @@
           button.disabled = true;
 
           // Request combination from server
-          const response = await fetch("https://yt.brianfromm.com/combine", {
+          const response = await fetch("/combine", {
             method: "POST",
             headers: {
               "Content-Type": "application/json",
@@ -574,7 +574,7 @@
           const currentUrl = urlInput.value.trim();
 
           // Use the new server-side download route
-          const downloadUrl = `https://yt.brianfromm.com/download/${formatId}?url=${encodeURIComponent(
+          const downloadUrl = `/download/${formatId}?url=${encodeURIComponent(
             currentUrl
           )}`;
 
@@ -611,7 +611,7 @@
         showLoading();
 
         try {
-          const response = await fetch("https://yt.brianfromm.com/extract", {
+          const response = await fetch("/extract", {
             method: "POST",
             headers: {
               "Content-Type": "application/json",


### PR DESCRIPTION
## Description

Replace absolute URLs with relative paths for /combine, /download, and /extract endpoints

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring

## Testing

- [x] Tested locally
- [x] GitHub Actions pass
- [x] Manual testing completed

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated if needed
- [x] No breaking changes (or clearly documented)
