### PR TITLE
feat: configure semantic-release with custom release rules

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,7 +1,21 @@
 {
   "branches": ["main"],
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "releaseRules": [
+          { "type": "feat", "release": "minor" },
+          { "type": "feat", "breaking": true, "release": "major" },
+          { "type": "fix", "release": "patch" },
+          { "type": "docs", "release": "patch" },
+          { "type": "style", "release": "patch" },
+          { "type": "refactor", "release": "patch" },
+          { "type": "test", "release": "patch" },
+          { "type": "chore", "release": "patch" }
+        ]
+      }
+    ],
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
     "@semantic-release/github"


### PR DESCRIPTION
## Description

Adds custom release rules to semantic-release so that:
- `docs:`, `style:`, `refactor:`, `test:`, and `chore:` all trigger patch bumps
- `feat!:` and `BREAKING CHANGE:` trigger major version bumps

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Testing

- [x] Tested locally
- [x] GitHub Actions pass
- [x] Manual testing completed

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated if needed
- [x] No breaking changes (or clearly documented)
