### PR TITLE
chore: Remove docker compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   youtube-extractor:
     image: ghcr.io/brianfromm/youtube-video-extractor:latest


### PR DESCRIPTION
## Description

Docker Compose v2 no longer uses the 'version' field and logs a warning when it's present:
"WARN: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"

This commit removes the field to clean up logs and follow current Compose best practices.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring

## Testing

- [x] Tested locally
- [x] GitHub Actions pass
- [x] Manual testing completed

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated if needed
- [x] No breaking changes (or clearly documented)
