### PR TITLE
feat: add Gunicorn production server with environment configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Local files
 .DS_Store
+.env.local
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,9 @@ RUN mkdir -p /tmp/ytextractor && chmod 777 /tmp/ytextractor
 # Expose port 8080
 EXPOSE 8080
 
-# Run the application
-CMD ["python", "server.py"]
+# Use environment variable to determine how to run
+CMD if [ "$USE_DEV_SERVER" = "true" ]; then \
+        python server.py; \
+    else \
+        gunicorn --bind 0.0.0.0:8080 --workers 4 --timeout 300 server:app; \
+    fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
 services:
   youtube-extractor:
-    image: ghcr.io/brianfromm/youtube-video-extractor:latest
+    image: ${COMPOSE_IMAGE:-ghcr.io/brianfromm/youtube-video-extractor:latest}
+    build:
+      context: .
+    platform: ${COMPOSE_PLATFORM:-linux/amd64}
     container_name: youtube-extractor
     ports:
       - "8080:8080"
@@ -8,6 +11,7 @@ services:
       - /tmp:/tmp
     environment:
       - FLASK_ENV=production
+      - USE_DEV_SERVER=${USE_DEV_SERVER:-false}
     restart: unless-stopped
     labels:
       - "com.centurylinklabs.watchtower.enable=true"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ flask==3.0.0
 flask-cors==4.0.0
 yt-dlp
 requests
+gunicorn


### PR DESCRIPTION
## Description

- Add Gunicorn to requirements.txt for production-grade WSGI server
- Update Dockerfile to conditionally use Flask dev server or Gunicorn based on USE_DEV_SERVER env var
- Configure docker-compose.yml to support .env.local overrides for local development
- Enable platform-specific builds (ARM64 for local dev, AMD64 for production)
- Improve concurrent request handling with 4 Gunicorn workers and 5-minute timeout
- Maintain backward compatibility with existing production deployments

Development usage: docker-compose --env-file .env.local up --build
Production usage: docker-compose up --build

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Testing

- [x] Tested locally
- [x] GitHub Actions pass
- [x] Manual testing completed

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated if needed
- [x] No breaking changes (or clearly documented)
