### PR TITLE
chore: bump dependencies and fix direct merge progress UI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,6 @@
 line-length = 120
 target-version = ["py312"]
 
-[tool.isort]
-profile = "black"
-
 [tool.ruff]
 line-length = 120
 target-version = "py312"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,9 +7,6 @@ ruff>=0.15.9
 # Code formatter
 black>=26.3.1
 
-# Import sorting (works with black)
-isort>=7.0.0
-
 # Traditional comprehensive linter (optional, for detailed analysis)
 pylint>=4.0.5
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,16 +2,16 @@
 # Install with: pip install -r requirements-dev.txt
 
 # Modern fast linter (replaces flake8, isort, and more)
-ruff>=0.14.14
+ruff>=0.15.9
 
 # Code formatter
-black>=26.1.0
+black>=26.3.1
 
 # Import sorting (works with black)
 isort>=7.0.0
 
 # Traditional comprehensive linter (optional, for detailed analysis)
-pylint>=4.0.4
+pylint>=4.0.5
 
 # Type checking (optional)
-mypy>=1.19.1
+mypy>=1.20.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-flask>=3.1.2
+flask>=3.1.3
 flask-cors>=6.0.2
-yt-dlp[default]>=2025.12.08
-gunicorn==25.0.3
+yt-dlp[default]>=2026.3.17
+gunicorn>=25.3.0
 urllib3>=2.6.3
-werkzeug>=3.1.5
-certifi>=2026.1.4
+werkzeug>=3.1.8
+certifi>=2026.2.25
 pip-audit>=2.10.0
-bgutil-ytdlp-pot-provider>=1.2.2
+bgutil-ytdlp-pot-provider>=1.3.1

--- a/server.py
+++ b/server.py
@@ -874,6 +874,10 @@ def _perform_combination_task(task_details):  # Renamed from _perform_actual_com
 
         if is_video_compatible and is_audio_compatible:
             compatible_for_direct_merge = True
+            # Signal to frontend immediately so it can show the right progress UI
+            current_status = task_statuses.get(task_id, {})
+            current_status["merge_type"] = "direct"
+            task_statuses[task_id] = current_status
             app.logger.info(
                 f"✅ Task {task_id}: Formats compatible for direct merge. "
                 f"Video: {video_vcodec} ({video_ext}), Audio: {audio_acodec} ({audio_ext})."
@@ -1574,11 +1578,20 @@ def download_processed_file(task_id):
                 f"[DOWNLOAD_PROCESSED] Task {task_id}: File '{actual_file_path_on_disk}' found. "
                 f"Serving as '{download_name_header}'."
             )
+            # Override MIME types that Python's mimetypes module gets wrong
+            # (e.g., .m4a → audio/mp4a-latm instead of audio/mp4, which browsers flag as insecure)
+            mime_overrides = {
+                ".m4a": "audio/mp4",
+                ".webm": "audio/webm",
+            }
+            ext = os.path.splitext(actual_file_path_on_disk)[1].lower()
+            mimetype = mime_overrides.get(ext)
             return send_from_directory(
                 os.path.dirname(actual_file_path_on_disk),
                 os.path.basename(actual_file_path_on_disk),
                 as_attachment=True,
                 download_name=download_name_header,
+                mimetype=mimetype,
             )
         else:
             app.logger.error(

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -156,7 +156,7 @@ function addCombinedSection(videoFormats, audioFormats) {
     combinedItem.innerHTML = `
     <div class="format-item-content">
         <div class="format-details">
-            <div class="format-type">⚡ ${videoQualityDisplay} + Best Audio (MP4) [Format ${videoFormat.format_id}]</div>
+            <div class="format-type">⚡ ${videoQualityDisplay} + Best Audio (MP4)</div>
             <div class="format-specs">${codecInfo}</div>
         </div>
         <div style="display: flex; gap: 8px;">
@@ -605,6 +605,19 @@ function pollTaskStatus(
       let statusText =
         data.status.charAt(0).toUpperCase() + data.status.slice(1);
 
+      if (data.status === "queued" || data.status === "processing") {
+        // For direct merge tasks, switch to simple UI as soon as we know
+        if (data.merge_type === "direct" && buttonElement.progressContainer) {
+          const pc = buttonElement.progressContainer;
+          const audioPhase = pc.querySelector('[data-phase="audio"]');
+          const combiningPhase = pc.querySelector('[data-phase="combining"]');
+          const videoLabel = pc.querySelector('[data-phase="video"] .phase-label');
+          if (audioPhase) audioPhase.style.display = "none";
+          if (combiningPhase) combiningPhase.style.display = "none";
+          if (videoLabel) videoLabel.textContent = "Downloading:";
+        }
+      }
+
       if (data.status === "queued") {
         // Queued state - progress UI already shows "Queued", button shows "Cancel"
         // Nothing to do here, just continue polling
@@ -651,8 +664,28 @@ function pollTaskStatus(
             const audioFill = audioPhase.querySelector(".progress-bar-fill");
 
             // Update phases based on current state
-            if (phase.includes("downloading_video")) {
+            if (phase.includes("downloading_combined")) {
+              // Direct merge: yt-dlp downloads and merges in one step
+              // Show a single simplified progress bar using the video phase element
               const percent = data.progress_percent || 0;
+              videoPhase.querySelector(".phase-label").textContent =
+                "Downloading:";
+              videoPhase.querySelector(".phase-icon").textContent = "⏳";
+              videoPhase.querySelector(".phase-status").textContent = `${
+                data.progress_percent
+                  ? data.progress_percent.toFixed(0) + "%"
+                  : "In progress..."
+              }`;
+              videoProgress.style.display = "block";
+              videoFill.style.width = percent + "%";
+              audioPhase.style.display = "none";
+              combiningPhase.style.display = "none";
+            } else if (phase.includes("downloading_video")) {
+              const percent = data.progress_percent || 0;
+              videoPhase.style.display = "";
+              audioPhase.style.display = "";
+              combiningPhase.style.display = "";
+              videoPhase.querySelector(".phase-label").textContent = "Video:";
               videoPhase.querySelector(".phase-icon").textContent = "⏳";
               videoPhase.querySelector(".phase-status").textContent = `${
                 data.progress_percent


### PR DESCRIPTION
## Summary
- Bump all production and dev dependencies to latest versions (flask, yt-dlp, gunicorn, werkzeug, certifi, bgutil, ruff, black, pylint, mypy)
- Unpin gunicorn from `==25.0.3` to `>=25.3.0` (upstream regression now resolved)
- Remove isort dependency — ruff already handles import sorting via the `"I"` rule
- Fix direct merge (H.264+AAC) combination downloads showing three stuck "Waiting..." phases — now displays a single moving progress bar
- Fix audio download MIME type (`.m4a` served as `audio/mp4` instead of `audio/mp4a-latm` which browsers flagged as insecure)
- Remove format IDs from combination download button labels

## Test plan
- [ ] Test 720p/1080p combination download (direct merge) — should show single progress bar
- [ ] Test 1440p/2160p combination download (transcode) — should show three-phase progress
- [ ] Test individual audio download — verify no browser security warnings in prod
- [ ] Verify gunicorn 25.3.0 starts and serves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)