### PR TITLE
chore: remove gunicorn version ignore from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,9 +14,6 @@ updates:
     labels:
       - "dependencies"
       - "python"
-    ignore:
-      - dependency-name: "gunicorn"
-        versions: ["25.1.0"]
     commit-message:
       prefix: "chore"
       prefix-development: "chore"


### PR DESCRIPTION
## Summary
- Remove the `ignore` rule for gunicorn 25.1.0 from dependabot config
- The upstream regression that prompted this ignore has been resolved
- Gunicorn is now unpinned at `>=25.3.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)