### PR TITLE
chore: bump ruff and mypy dev dependency floors

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 # Install with: pip install -r requirements-dev.txt
 
 # Modern fast linter (replaces flake8, isort, and more)
-ruff>=0.15.9
+ruff>=0.15.11
 
 # Code formatter
 black>=26.3.1
@@ -11,4 +11,4 @@ black>=26.3.1
 pylint>=4.0.5
 
 # Type checking (optional)
-mypy>=1.20.0
+mypy>=1.20.1


### PR DESCRIPTION
## Summary
- Bump `ruff` floor from 0.15.9 → 0.15.11 (patch)
- Bump `mypy` floor from 1.20.0 → 1.20.1 (patch)

Dev-only linter/type-checker patches surfaced by `/check-deps`. Production `requirements.txt` is already at latest across the board.

## Test plan
- [ ] `pip install -r requirements-dev.txt` succeeds
- [ ] `ruff check .` runs clean
- [ ] `mypy` runs clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)