### PR TITLE
chore: bump certifi, ruff, mypy patch versions

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 # Install with: pip install -r requirements-dev.txt
 
 # Modern fast linter (replaces flake8, isort, and more)
-ruff>=0.15.11
+ruff>=0.15.12
 
 # Code formatter
 black>=26.3.1
@@ -11,4 +11,4 @@ black>=26.3.1
 pylint>=4.0.5
 
 # Type checking (optional)
-mypy>=1.20.1
+mypy>=1.20.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ yt-dlp[default]>=2026.3.17
 gunicorn>=25.3.0
 urllib3>=2.6.3
 werkzeug>=3.1.8
-certifi>=2026.2.25
+certifi>=2026.4.22
 pip-audit>=2.10.0
 bgutil-ytdlp-pot-provider>=1.3.1


### PR DESCRIPTION
## Summary
- Bump `certifi` floor `2026.2.25` → `2026.4.22` (CA bundle refresh)
- Bump `ruff` floor `0.15.11` → `0.15.12` (patch)
- Bump `mypy` floor `1.20.1` → `1.20.2` (patch)

All patch-level bumps surfaced by `/check-deps`. No major versions outstanding.

## Test plan
- [ ] `pip install -r requirements.txt -r requirements-dev.txt` clean
- [ ] App boots locally (`./start.sh`)
- [ ] `ruff check .` passes
- [ ] `mypy` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)