### PR TITLE
chore: bump ruff to 0.15.15 and fix E501 in server.py

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 # Install with: pip install -r requirements-dev.txt
 
 # Modern fast linter (replaces flake8, isort, and more)
-ruff>=0.15.14
+ruff>=0.15.15
 
 # Code formatter
 black>=26.5.1

--- a/server.py
+++ b/server.py
@@ -1673,7 +1673,12 @@ if __name__ == "__main__":
         )
         # debug=True enables auto-reloader and debugger. Flask's reloader handles threads better.
         # threaded=True is generally good for dev server to handle multiple requests like polling.
-        app.run(host="0.0.0.0", port=flask_port_info, debug=os.environ.get("FLASK_DEBUG", "false").lower() == "true", threaded=True)
+        app.run(
+            host="0.0.0.0",
+            port=flask_port_info,
+            debug=os.environ.get("FLASK_DEBUG", "false").lower() == "true",
+            threaded=True,
+        )
     else:
         # When using Gunicorn, it will run the 'app' object directly.
         # The host and port will be configured via Gunicorn's command line arguments.


### PR DESCRIPTION
## Summary
- Bump `ruff` pin floor from 0.15.14 to 0.15.15 (patch release, no new lint findings)
- Wrap the long `app.run()` call in `server.py` to fix the one pre-existing E501 (132 > 120 chars)

## Verification
- `ruff check .` — all checks passed (verified the E501 was pre-existing, not a 0.15.15 regression, by running both versions)
- `black --check server.py` — formatting unchanged
- Syntax validated

## Notes
The open Dependabot PR for ruff 0.15.15 will auto-close/rebase once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)