### PR TITLE
chore: bump dependencies (flask-cors, yt-dlp, pip-audit, ruff, pylint)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,13 +2,13 @@
 # Install with: pip install -r requirements-dev.txt
 
 # Modern fast linter (replaces flake8, isort, and more)
-ruff>=0.15.15
+ruff>=0.15.17
 
 # Code formatter
 black>=26.5.1
 
 # Traditional comprehensive linter (optional, for detailed analysis)
-pylint>=4.0.5
+pylint>=4.0.6
 
 # Type checking (optional)
 mypy>=2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 flask>=3.1.3
-flask-cors>=6.0.2
-yt-dlp[default]>=2026.3.17
+flask-cors>=6.0.5
+yt-dlp[default]>=2026.6.9
 gunicorn>=26.0.0
 urllib3>=2.7.0
 werkzeug>=3.1.8
 certifi>=2026.5.20
-pip-audit>=2.10.0
+pip-audit>=2.10.1
 bgutil-ytdlp-pot-provider>=1.3.1


### PR DESCRIPTION
## Summary

Routine dependency bumps (all patch or date-versioned, no majors):

- **Production:** flask-cors → 6.0.5, yt-dlp → 2026.6.9, pip-audit → 2.10.1
- **Dev:** ruff → 0.15.17, pylint → 4.0.6

Installed and verified locally.

## Test plan

- [ ] Smoke-test a download / format listing (yt-dlp 2026.3.17 → 2026.6.9 is the most behaviorally significant bump)
- [ ] Run linters (ruff, pylint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)