### PR TITLE
chore: bump deps (certifi, ruff) and actions/checkout to v7

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 # Install with: pip install -r requirements-dev.txt
 
 # Modern fast linter (replaces flake8, isort, and more)
-ruff>=0.15.17
+ruff>=0.15.20
 
 # Code formatter
 black>=26.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ yt-dlp[default]>=2026.6.9
 gunicorn>=26.0.0
 urllib3>=2.7.0
 werkzeug>=3.1.8
-certifi>=2026.5.20
+certifi>=2026.6.17
 pip-audit>=2.10.1
 bgutil-ytdlp-pot-provider>=1.3.1


### PR DESCRIPTION
## Summary

Bundled dependency maintenance from `/check-deps` plus folds in Dependabot PR #69.

### Python dependencies
- **certifi** 2026.5.20 → 2026.6.17 (CA root bundle refresh, data-only)
- **ruff** 0.15.17 → 0.15.20 (patch-level bugfixes)

All other production/dev pins are already at latest. `ruff check .` passes clean.

### CI
- **actions/checkout** v6 → v7 in `docker-build.yml` and `release.yml` (folds in #69)

v7's only behavioral change relevant here is blocking fork-PR checkout for `pull_request_target`/`workflow_run` triggers — neither workflow uses those, so the upgrade is safe.

## Test plan
- [x] `ruff check .` — all checks passed
- [x] `pip install -r requirements.txt -r requirements-dev.txt` — installs clean

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)